### PR TITLE
Fix wrong reference to global `pubnub` -> `self.pubnub`

### DIFF
--- a/pubnub-c3.js
+++ b/pubnub-c3.js
@@ -434,8 +434,7 @@ window.eon.c = {
 
       if(options.channelGroups) {
 
-        // assuming an intialized PubNub instance already exists
-        pubnub.channelGroups.listChannels({
+        self.pubnub.channelGroups.listChannels({
             channelGroup: options.channelGroups
           }, function (status, response) {
             


### PR DESCRIPTION
This PR fixes a wrong reference to `pubnub`, which implies it available in a global/scoped variable.